### PR TITLE
Minor buildsystem mods.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ cmake_minimum_required(VERSION 2.8)
 # For running "make test"
 enable_testing()
 
-find_package(Eigen3 REQUIRED)
-
 set(EQUELLE_MAJOR_VERSION 0)
 set(EQUELLE_MINOR_VERSION 1)
 set(EQUELLE_PATCH_VERSION 0)

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT MSVC)
 	set( CMAKE_CXX_FLAGS "-std=c++0x -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-deprecated-register -Wno-unneeded-internal-declaration" )
 endif()
 
-find_package( BISON REQUIRED )
+find_package( BISON 3 REQUIRED )
 find_package( FLEX REQUIRED )
 find_package( Boost REQUIRED COMPONENTS program_options )
 


### PR DESCRIPTION
In particular:
 - Eigen search only performed in backend/serial subdir.
 - Bison must be at least version 3.

Will self-merge.