### PR TITLE
Modify two legacy examples so they still compile.

### DIFF
--- a/examples/app/heateq.cpp
+++ b/examples/app/heateq.cpp
@@ -8,7 +8,7 @@ void ensureRequirements(const equelle::EquelleRuntimeCPU& er);
 int main(int argc, char** argv)
 {
     // Get user parameters.
-    Opm::parameter::ParameterGroup param(argc, argv, false);
+    Opm::ParameterGroup param(argc, argv, false);
     
     using namespace equelle;
 

--- a/examples/app/heateq_timesteps.cpp
+++ b/examples/app/heateq_timesteps.cpp
@@ -8,7 +8,7 @@ void ensureRequirements(const equelle::EquelleRuntimeCPU& er);
 int main(int argc, char** argv)
 {
     // Get user parameters.
-    Opm::parameter::ParameterGroup param(argc, argv, false);
+    Opm::ParameterGroup param(argc, argv, false);
 
     using namespace equelle;
     // Create the Equelle runtime.


### PR DESCRIPTION
They represent an earlier stage of the compiler output, so we could consider removing them.