### PR TITLE
Normalize normals, init CudaArray and change to cusp::monitor

### DIFF
--- a/backends/cuda/cuda_include/CudaArray.hpp
+++ b/backends/cuda/cuda_include/CudaArray.hpp
@@ -50,7 +50,7 @@ namespace equelleCUDA {
 	
 	//! Allocating constructor
 	/*! 
-	  Allocates device memory for the collection. Does not initialize the collection. 
+	  Allocates device memory for the collection and initialize to zero.
 	  \param size number of scalars in the collection.
 	*/
 	explicit CudaArray(const int size);

--- a/backends/cuda/cuda_include/DeviceGrid.hpp
+++ b/backends/cuda/cuda_include/DeviceGrid.hpp
@@ -614,8 +614,14 @@ namespace equelleCUDA
 				       const int num_vectors,
 				       const int dimensions);
 
+    
+	__global__ void normalizeAllFaceNormals( double* normals, 
+                                             const double* face_areas_,
+                                             const int num_vectors,
+                                             const int dimensions);
 
     } // namespace wrapDeviceGrid
+
 
 
 } // namespace equelleCUDA

--- a/backends/cuda/src/cudaArray.cu
+++ b/backends/cuda/src/cudaArray.cu
@@ -37,13 +37,14 @@ CudaArray::CudaArray()
 }
 
 
-// Allocating memory without initialization
+// Allocate and initialize to zero
 CudaArray::CudaArray(const int size) 
     : size_(size),
       dev_values_(0),
       setup_(size_)
 {
     cudaStatus_ = cudaMalloc( (void**)&dev_values_, size_*sizeof(double));
+    setUniformDouble<<<setup_.grid, setup_.block>>>( dev_values_, 0.0, size_);
     checkError_("cudaMalloc in CudaArray::CudaArray(int)");
 }
 

--- a/backends/cuda/src/deviceGrid.cu
+++ b/backends/cuda/src/deviceGrid.cu
@@ -177,7 +177,7 @@ DeviceGrid::DeviceGrid( const UnstructuredGrid& grid)
 			      cudaMemcpyHostToDevice );
     checkError_("cudaMemcpy(face_normals_) in DeviceGrid::DeviceGrid(UnstructuredGrid&)");
 
-
+    // Normalize the face normals. They are scaled relative to the area of the faces.
     kernelSetup s(number_of_faces_);
     normalizeAllFaceNormals<<<s.grid,s.block>>>(face_normals_, face_areas_, number_of_faces_, dimensions_);
     cudaDeviceSynchronize();
@@ -279,6 +279,7 @@ DeviceGrid::DeviceGrid(const DeviceGrid& grid)
 			      cudaMemcpyDeviceToDevice);
     checkError_("cudaMemcpy(face_normals_) in DeviceGrid::DeviceGrid(const DeviceGrid&)");
 
+    // Normalize the face normals. They are scaled relative to the area of the faces.
     kernelSetup s(number_of_faces_);
     normalizeAllFaceNormals<<<s.grid,s.block>>>(face_normals_, face_areas_, number_of_faces_, dimensions_);
     cudaDeviceSynchronize();

--- a/backends/cuda/src/deviceGrid.cu
+++ b/backends/cuda/src/deviceGrid.cu
@@ -177,6 +177,11 @@ DeviceGrid::DeviceGrid( const UnstructuredGrid& grid)
 			      cudaMemcpyHostToDevice );
     checkError_("cudaMemcpy(face_normals_) in DeviceGrid::DeviceGrid(UnstructuredGrid&)");
 
+
+    kernelSetup s(number_of_faces_);
+    normalizeAllFaceNormals<<<s.grid,s.block>>>(face_normals_, face_areas_, number_of_faces_, dimensions_);
+    cudaDeviceSynchronize();
+
 } // Constructor from OPMs UnstructuredGrid
 
 
@@ -273,7 +278,10 @@ DeviceGrid::DeviceGrid(const DeviceGrid& grid)
 			      dimensions_ * number_of_faces_ * sizeof(double),
 			      cudaMemcpyDeviceToDevice);
     checkError_("cudaMemcpy(face_normals_) in DeviceGrid::DeviceGrid(const DeviceGrid&)");
-    
+
+    kernelSetup s(number_of_faces_);
+    normalizeAllFaceNormals<<<s.grid,s.block>>>(face_normals_, face_areas_, number_of_faces_, dimensions_);
+    cudaDeviceSynchronize();
 } // copy constructor
 
 
@@ -861,5 +869,31 @@ __global__ void wrapDeviceGrid::faceNormalsKernel( double* out,
 	for( int i = 0; i < dimensions; i++) {
 	    out[vec_id*dimensions + i] = all_face_normals[face_id*dimensions + i];
 	}
+    }
+}
+
+
+
+// NORMALIZE FACE NORMALS
+__global__ void wrapDeviceGrid::normalizeAllFaceNormals( double* normals, 
+                                                         const double* face_areas_,
+                                                         const int num_vectors,
+                                                         const int dimensions)
+{
+    // One thread for each vector
+    const int face_id = myID();
+    if ( face_id < num_vectors ) {
+        if(dimensions == 1){
+            normals[face_id] /= face_areas_[face_id];
+        } else
+        if(dimensions == 2){
+            normals[face_id] /= face_areas_[face_id];
+            normals[face_id*dimensions+1] /= face_areas_[face_id];
+        } else
+        if(dimensions == 3) {
+            normals[face_id*dimensions]   /= face_areas_[face_id];
+            normals[face_id*dimensions+1] /= face_areas_[face_id];
+            normals[face_id*dimensions+2] /= face_areas_[face_id];
+        }
     }
 }

--- a/backends/cuda/src/linearSolver.cu
+++ b/backends/cuda/src/linearSolver.cu
@@ -155,7 +155,7 @@ CollOfScalar LinearSolver::solve(const CudaMatrix& A_cpy,
 		       cusp_A_csrRowPtr, cusp_A_csrColInd, cusp_A_csrVal );
 
     // Create a monitor
-    cusp::default_monitor<double> monitor(cusp_b, maxit_, tol_);
+    cusp::monitor<double> monitor(cusp_b, maxit_, tol_);
 
     // Solve according to solver and preconditioner:
     if ( solver_ == BiCGStab && precond_ == DIAG ) {


### PR DESCRIPTION
Changing to cusp::monitor is mainly to silence a deprecation warning. cusp::default_monitor and cusp::monitor are equivalent.